### PR TITLE
Improve error reporting

### DIFF
--- a/validate_email/mx_check.py
+++ b/validate_email/mx_check.py
@@ -125,7 +125,7 @@ def _check_one_mx(
     `StopIteration` if this MX accepts the email.
     """
     try:
-        smtp_converse(
+        _smtp_converse(
             mx_record=mx_record, smtp_timeout=smtp_timeout, debug=debug,
             helo_host=helo_host, from_address=from_address,
             email_address=email_address)

--- a/validate_email/mx_check.py
+++ b/validate_email/mx_check.py
@@ -125,7 +125,7 @@ def _check_one_mx(
     `StopIteration` if this MX accepts the email.
     """
     try:
-        result = _smtp_converse(
+        smtp_converse(
             mx_record=mx_record, smtp_timeout=smtp_timeout, debug=debug,
             helo_host=helo_host, from_address=from_address,
             email_address=email_address)


### PR DESCRIPTION
* Unify error message format, always include SMTP status code
* Use "with SMTP" to properly close connection even in case of error
* Establish connection after setting debug level so this is debugged as
  well
* Properly handle SMTP error status codes on connection
* Don't return ambigious SMTP status codes, as they are not used anyway

@karolyi @manojr2k I tried with some domains, but I think it would be good if you could do some more checks with this code before doing a release.