### PR TITLE
Proposal to let the caller analyse the reason for ambiguous verification results

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,9 +31,9 @@ Basic usage::
 
 :code:`check_mx`: check the mx-records and check whether the email actually exists
 
-:code:`from_address`: the email address the probe will be sent from,
+:code:`from_address`: the email address the probe will be sent from
 
-:code:`helo_host`: the host to use in SMTP HELO when checking for an email,
+:code:`helo_host`: the host to use in SMTP HELO when checking for an email
 
 :code:`smtp_timeout`: seconds until SMTP timeout
 
@@ -44,6 +44,10 @@ Basic usage::
 :code:`debug`: emit debug/warning messages while checking email
 
 :code:`skip_smtp`: (default :code:`False`) skip the SMTP conversation with the server, after MX checks. Will automatically be set to :code:`True` when :code:`check_mx` is :code:`False`!
+
+:code:`raise_communication_errors`: Affects the SMTP verification step. If set to :code:`True`, any connection error or SMTP error message from the server will lead to a negative verification result, otherwise it will be regarded as an ambiguous result. Defaults to :code:`False`. This option is mainly used in connection with :code:`validate_email_or_fail()`, where the exception raised can be analyzed to find out the reason for the otherwise ambiguous result.
+
+:code:`raise_temporary_errors`: Affects the SMTP verification step. If set to :code:`True`, a temporary error reply of the SMTP server to the :code:`RCPT TO` command (as used, for example, with greylisting) will lead to a negative verification result, otherwise it will be regarded as an ambiguous result. Defaults to :code:`False`. This option is mainly used in connection with :code:`validate_email_or_fail()`, where the exception raised can be analyzed to find out the reason for the otherwise ambiguous result.
 
 The function :code:`validate_email_or_fail()` works exactly like :code:`validate_email`, except that it raises an exception in the case of validation failure instead of returning :code:`False`.
 

--- a/validate_email/mx_check.py
+++ b/validate_email/mx_check.py
@@ -104,7 +104,7 @@ def _smtp_mail(smtp: SMTP, from_address: EmailAddress):
 def _smtp_converse(
         mx_record: str, smtp_timeout: int, debug: bool, helo_host: str,
         from_address: EmailAddress, email_address: EmailAddress
-    ) -> Tuple[int, str]:
+        ) -> Tuple[int, str]:
     """
     Do the `SMTP` conversation with one MX, and return code and message
     of the reply to the `RCPT TO:` command.
@@ -175,7 +175,7 @@ def mx_check(
         dns_timeout: int = 10, skip_smtp: bool = False,
         raise_communication_errors: bool = False,
         raise_temporary_errors: bool = False
-    ) -> Optional[bool]:
+        ) -> Optional[bool]:
     """
     Verify the given email address by determining the SMTP servers
     responsible for the domain and then asking them to deliver an

--- a/validate_email/validate_email.py
+++ b/validate_email/validate_email.py
@@ -16,7 +16,8 @@ def validate_email_or_fail(
         from_address: Optional[str] = None, helo_host: Optional[str] = None,
         smtp_timeout: int = 10, dns_timeout: int = 10,
         use_blacklist: bool = True, debug: bool = False,
-        skip_smtp: bool = False) -> Optional[bool]:
+        skip_smtp: bool = False, raise_communication_errors: bool = False,
+        raise_temporary_errors: bool = False) -> Optional[bool]:
     """
     Return `True` if the email address validation is successful, `None` if the
     validation result is ambigious, and raise an exception if the validation
@@ -38,7 +39,9 @@ def validate_email_or_fail(
     return mx_check(
         email_address=email_address, from_address=from_address,
         helo_host=helo_host, smtp_timeout=smtp_timeout,
-        dns_timeout=dns_timeout, skip_smtp=skip_smtp, debug=debug)
+        dns_timeout=dns_timeout, skip_smtp=skip_smtp, debug=debug,
+        raise_communication_errors=raise_communication_errors,
+        raise_temporary_errors=raise_temporary_errors)
 
 
 def validate_email(email_address: str, *args, **kwargs):


### PR DESCRIPTION
This is my proposal for allowing the caller of `validate_email_or_fail` to analyze the reasons for ambiguous verification results and, if desired, react appropriately.

It adds two new parameters:

`raise_communication_errors` can be set to `True` to raise an `SMTPCommunicationError` exception in case we don't even get to the `RCPT TO` step in the SMTP communication. The exception contains all information to analyze the exact error code and message. If the parameter is set to `False` (the default), such a case is considered an ambiguous verification result, and the check function returns `None`.

`raise_temporary_errors` can be set to `True` to raise an `SMTPTemporaryError` exception in case the `RCPT TO` command is answered with a 4xx status code. The exception contains all information to analyze the exact error code and message. If the parameter is set to `False` (the default), such a case is considered an ambiguous verification result, and the check function returns `None`.

Comments, bug reports, and suggestions for improvements are welcome!